### PR TITLE
CAPI 1.5 BFS: Improvements

### DIFF
--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG golang_image
+
 # Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
 # Build architecture
 ARG ARCH
+
+FROM ${golang_image} as custom_golang_image
 
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
@@ -29,10 +33,13 @@ FROM ${builder_image} as builder
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
+COPY --from=custom_golang_image /usr/lib/golang/ /usr/lib/golang/
+RUN ln -s /usr/lib/golang/bin/go /usr/bin/go
+
 RUN dnf install -y oracle-olcne-release-el8 oraclelinux-developer-release-el8 && \
     dnf config-manager --enable ol8_olcne16 ol8_developer && \
     dnf update -y && \
-    dnf install -y openssl-devel delve gcc go-toolset-1.19.6 && \
+    dnf install -y openssl-devel delve gcc && \
     go version
 
 # Gets additional CAPD dependencies


### PR DESCRIPTION
- Extract clusterctl from containerized build for release. Avoid unnecessary bare-metal compilation of clusterctl for release.
- Updated `capd-manager` to use custom golang. Note: This image is not used as part of the release.
