### PR TITLE
VZ-11469 - use distroless base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,13 +67,15 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
 # Production image
 
 FROM $FINAL_IMAGE
-WORKDIR /
-COPY --from=builder /workspace/manager .
 
 # Copy users and groups
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
-COPY --from=builder /home/ocne /home/ocne
+
+WORKDIR /
+
+COPY --from=builder --chown=1000:ocne --chmod=500 /workspace/manager .
+COPY --from=builder --chown 1000:ocne /home/ocne /home/ocne
 COPY --from=builder /ocne /ocne
 
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ COPY --from=builder /etc/group /etc/group
 WORKDIR /
 
 COPY --from=builder --chown=1000:ocne --chmod=500 /workspace/manager .
-COPY --from=builder --chown 1000:ocne /home/ocne /home/ocne
-COPY --from=builder /ocne /ocne
+COPY --from=builder --chown=1000:ocne /home/ocne /home/ocne
+COPY --from=builder --chown=1000:ocne /ocne /ocne
 
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ COPY --from=builder /etc/group /etc/group
 
 WORKDIR /
 
-COPY --from=builder --chown=1000:ocne --chmod=500 /workspace/manager .
+COPY --from=builder --chown=1000:ocne /workspace/manager .
 COPY --from=builder --chown=1000:ocne /home/ocne /home/ocne
 COPY --from=builder --chown=1000:ocne /ocne /ocne
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ARG builder_image
 # Build architecture
 ARG ARCH
 
+# Final production base image
+ARG FINAL_IMAGE=ghcr.io/verrazzano/ol8-static:v0.0.1-20231102152128-e7afc807
+
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
@@ -54,21 +57,26 @@ ARG ldflags
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -trimpath -ldflags "${ldflags} -extldflags '-static'" \
-    -o manager ${package}
-
-# Production image
-FROM ghcr.io/oracle/oraclelinux:8-slim
-RUN microdnf update \
-    && microdnf clean all
-WORKDIR /
-COPY --from=builder /workspace/manager .
-# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
-RUN groupadd -r ocne \
+    -o manager ${package} \
+    && groupadd -r ocne \
     && useradd --no-log-init -r -m -d /ocne -g ocne -u 1000 ocne \
     && mkdir -p /home/ocne \
-    && chown -R 1000:ocne /manager /home/ocne \
-    && chmod 500 /manager
-RUN mkdir -p /license
+    && chown -R 1000:ocne /workspace/manager /home/ocne \
+    && chmod 500 /workspace/manager
+
+# Production image
+
+FROM $FINAL_IMAGE
+WORKDIR /
+COPY --from=builder /workspace/manager .
+
+# Copy users and groups
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /home/ocne /home/ocne
+COPY --from=builder /ocne /ocne
+
+# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/
 USER 1000
 ENTRYPOINT ["/manager"]

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -16,6 +16,9 @@
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
+# Final production base image
+ARG FINAL_IMAGE=ghcr.io/verrazzano/ol8-static:v0.0.1-20231102152128-e7afc807
+
 # Build architecture
 ARG ARCH
 
@@ -59,12 +62,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     -o clusterctl ${package}
 
 # Production image
-FROM ghcr.io/oracle/oraclelinux:8-slim
-RUN microdnf update \
-    && microdnf clean all
+FROM $FINAL_IMAGE
 WORKDIR /
 COPY --from=builder /workspace/clusterctl .
-RUN mkdir -p /license
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 USER 65532


### PR DESCRIPTION
**What this PR does / why we need it**:
Use distroless base images to reduce the size and of container images, and exclude unneeded OS libraries

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #VZ-11469
